### PR TITLE
feat: update regions with latest DigitalOcean datacenters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,16 +5,18 @@
 # locals for regions
 locals {
   region = {
-    amsterdam-2 = "ams2"
     amsterdam-3 = "ams3"
+    atlanta-1   = "atl1"
     bangalore-1 = "blr1"
     frankfurt-1 = "fra1"
-    london-1    = "lon-1"
+    london-1    = "lon1"
     newyork-1   = "nyc1"
     newyork-2   = "nyc2"
     newyork-3   = "nyc3"
-    francisco-1 = "sfo1"
+    francisco-2 = "sfo2"
+    francisco-3 = "sfo3"
     singapore-1 = "sgp1"
+    sydney-1    = "syd1"
     toronto-1   = "tor1"
   }
 }


### PR DESCRIPTION
## Summary
- Updated the `locals.region` mapping to include all current DigitalOcean datacenters
- Removed outdated regions (ams2, sfo1) that are no longer available
- Added new regions (atl1, sfo2, sfo3, syd1) that are now available
- Fixed london-1 region slug from "lon-1" to "lon1" to match current API

## Changes Made
The following regions were updated based on the latest DigitalOcean documentation:

**Removed:**
- `amsterdam-2 = "ams2"` (outdated)
- `francisco-1 = "sfo1"` (outdated)

**Added:**
- `atlanta-1 = "atl1"` (new)
- `francisco-2 = "sfo2"` (new)
- `francisco-3 = "sfo3"` (new)
- `sydney-1 = "syd1"` (new)

**Fixed:**
- `london-1 = "lon-1"` → `london-1 = "lon1"` (corrected slug)

## Current Supported Regions
After this update, the module supports all 13 current DigitalOcean datacenters:
- NYC1, NYC2, NYC3 (New York)
- AMS3 (Amsterdam)
- SFO2, SFO3 (San Francisco)
- SGP1 (Singapore)
- LON1 (London)
- FRA1 (Frankfurt)
- TOR1 (Toronto)
- BLR1 (Bangalore)
- SYD1 (Sydney)
- ATL1 (Atlanta)

## Test Plan
- [ ] Verify terraform plan works with updated regions
- [ ] Test VPC creation in new regions (atl1, sfo2, sfo3, syd1)
- [ ] Ensure backward compatibility with existing infrastructure

🤖 Generated with [Claude Code](https://claude.ai/code)